### PR TITLE
ENH: ignore main branch when building and testing

### DIFF
--- a/.github/workflows/build-test-ci.yml
+++ b/.github/workflows/build-test-ci.yml
@@ -1,6 +1,9 @@
 name: Build and test
 
-on: [push]
+on:
+  push:
+    branches-ignore:
+      - main
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Ignore main branch on build-and-test workflow