### PR TITLE
ENH: add display swap when importing fonts

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,7 +9,10 @@ import App from 'src/components/App'
 
 WebFont.load({
   google: {
-    families: ['Fira Sans:300,800', 'Roboto Slab:300,400,800'],
+    families: [
+      'Fira Sans:300,800&display=swap',
+      'Roboto Slab:300,400,800&display=swap',
+    ],
   },
 })
 


### PR DESCRIPTION
As per PageSpeed recommendation, this adds the `display=swap` modifier when importing fonts with `webfontloader`.