### PR TITLE
FIX: remove font swap when importing

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,8 +10,8 @@ import App from 'src/components/App'
 WebFont.load({
   google: {
     families: [
-      'Fira Sans:300,800&display=swap',
-      'Roboto Slab:300,400,800&display=swap',
+      'Fira Sans:300,800',
+      'Roboto Slab:300,400,800',
     ],
   },
 })


### PR DESCRIPTION
Swap made `Roboto Slab` not work. Also didn't remove the warning from PageSpeed for `Fira Sans`.